### PR TITLE
ci: pin builds to Node 22 so release artifacts actually publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,10 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          # Node 22 (LTS). Do not bump to 24: electron-forge 7.11.2 packaging
+          # exits 0 mid-"Finalizing package" on Node 24, producing no
+          # distributables and publishing nothing. Verified on 22 and 25.
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,10 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          # Node 22 (LTS). Do not bump to 24: electron-forge 7.11.2 packaging
+          # exits 0 mid-"Finalizing package" on Node 24, producing no
+          # distributables and publishing nothing. Verified on 22 and 25.
+          node-version: 22
           cache: pnpm
 
       - name: Install Linux packaging tools

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -71,3 +71,4 @@ Do not reuse a version number that has ever been published — Squirrel caches b
 - `update.electronjs.org` only works for **public** repos. If the repo ever goes private, switch the updater to `UpdateSourceType.StaticStorage` (S3/R2) or self-host [Nucleus](https://github.com/atlassian/nucleus)/[Hazel](https://github.com/vercel/hazel).
 - The `version` in `package.json` is the single source of truth; tags are created by the publisher, never by hand.
 - Linux auto-update is intentionally out of scope (no Squirrel support); revisit with AppImage + electron-updater if Linux demand grows.
+- **CI builds run on Node 22 (LTS) — do not bump to Node 24.** On Node 24, electron-forge 7.11.2 packaging exits 0 partway through "Finalizing package" and produces **no distributables**, so the publish job goes green while creating no release. Verified working on Node 22 and 25, broken on 24. If artifacts ever stop appearing despite green jobs, check the Node version first.


### PR DESCRIPTION
## Problem
The first v1.1.0 release run (PR #4) showed all three OS publish jobs **green**, but **no GitHub release or tag was created**.

## Root cause
electron-forge 7.11.2 packaging exits with code 0 partway through `Finalizing package` on **Node 24** — it produces **zero distributables**, so the GitHub publisher uploads nothing and creates no release. The job still reports success.

Reproduced against the exact released commit with a frozen pnpm install:
- **Node 24.16** → fails: no `out/make` artifacts, clean exit 0 mid-finalize (matches CI)
- **Node 22.22** → succeeds: builds `ptstream-darwin-arm64-1.1.0.zip`
- **Node 25.8** → succeeds

## Fix
Pin `ci.yml` and `release.yml` to **Node 22 (LTS)**, with an inline comment and a note in `docs/RELEASES.md` so it doesn't regress.

Merging this re-runs the Release workflow; v1.1.0 doesn't exist yet, so it will build and publish for real.